### PR TITLE
Simplify TFHub Image

### DIFF
--- a/optional-dependencies.txt
+++ b/optional-dependencies.txt
@@ -17,7 +17,7 @@ pytesseract
 python-twitter
 scikit-learn
 seaborn
-spacy
+spacy>=3.2.0
 SpeechRecognition>=3.6.0
 tensorflow==2.4.0
 torch

--- a/optional-dependencies.txt
+++ b/optional-dependencies.txt
@@ -19,7 +19,7 @@ scikit-learn
 seaborn
 spacy
 SpeechRecognition>=3.6.0
-tensorflow>=2.0.0
+tensorflow==2.4.0
 torch
 transformers
 xlrd

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -54,17 +54,19 @@ class TFHubExtractor(Extractor):
             output for compatibility with extractor result
         transform_inp (optional): function to transform Stim.data 
             for compatibility with model input format
-        kwargs (dict): arguments to hub.KerasLayer call
+        keras_args (dict): arguments to hub.KerasLayer call
     '''
 
-    _log_attributes = ('url_or_path', 'features', 'transform_out')
+    _log_attributes = ('url_or_path', 'features', 'transform_out', 'keras_args')
     _input_type = Stim
 
     def __init__(self, url_or_path, features=None,
                  transform_out=None, transform_inp=None,
-                 **kwargs):
+                 keras_args=None):
         verify_dependencies(['tensorflow_hub'])
-        self.model = hub.KerasLayer(url_or_path, **kwargs)
+        if keras_args is None:
+            keras_args = {}
+        self.model = hub.KerasLayer(url_or_path, **keras_args)
         self.url_or_path = url_or_path
         self.features = features
         self.transform_out = transform_out
@@ -119,58 +121,30 @@ class TFHubImageExtractor(TFHubExtractor):
         features (optional): list of labels (for classification) 
             or other feature names. If not specified, returns 
             numbered features (feature_0, feature_1, ... ,feature_n)
-        rescale_rgb (bool): whether to rescale values to 0-1 range
-        reshape_input (tuple): if input needs to be reshaped, 
-            specifies target shape (height, width, n_channels).
-            Details on whether the model only accept a fixed size are
-            usually provided on the TFHub model page
-        kwargs (dict): arguments to hub.KerasLayer call
+        keras_args (dict): arguments to hub.KerasLayer call
     '''
 
     _input_type = ImageStim
-    _log_attributes = ('url_or_path', 'features', 'rescale_rgb', 
-                       'reshape_input')
+    _log_attributes = ('url_or_path', 'features', 'keras_args')
 
     def __init__(self, 
                  url_or_path, 
                  features=None,
-                 rescale_rgb=True, 
-                 reshape_input=None, 
                  input_dtype=tf.float32,
-                 **kwargs):
-        if not reshape_input:
-            logging.warning('Note that some models may require (or perform best with) '
-                            'specific input shapes. Incompatible shapes may raise errors'
-                            ' at extraction. Make sure you check the docs for '
-                            'your model on TFHub. If needed, you can reshape '
-                            'your input image by passing the desired target shape '
-                            '(height, width, n_channels) to reshape_input')
-        self.rescale_rgb = rescale_rgb
-        self.reshape_input = reshape_input
+                 keras_args=None):
+        
         self.input_dtype = input_dtype
-        super().__init__(url_or_path, features, **kwargs)
+
+        logging.warning('Some models may require specific input shapes.'
+                        ' Incompatible shapes may raise errors'
+                        ' at extraction. If needed, you can reshape'
+                        ' your input image using ImageResizingFilter,
+                        ' and rescale using ImageRescalingFilter')
+        super().__init__(url_or_path, features, keras_args=keras_args)
 
     def _preprocess(self, stim):
-        if self.reshape_input:
-            resizer = ImageResizingFilter(size=self.reshape_input[:-1])
-            x = resizer.transform(stim).data
-        else:
-            x = stim.data
-
-        if self.rescale_rgb:
-            if self.input_dtype.dtype.is_integer:
-                logging.warning('Rescaling the input from [0, 255] to [0, 1] and setting '
-                                'input_dtype to an integer type may result in loss of precision.'
-                                'Please, set rescale_rgb to False.')
-
-            x = x / 255.0
-
-        x = tf.convert_to_tensor(x, dtype=self.input_dtype)
+        x = tf.convert_to_tensor(stim.data, dtype=self.input_dtype)
         x = tf.expand_dims(x, axis=0)
-
-        if self.transform_inp:
-            return self.transform_inp(x)
-
         return x
 
 

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -66,6 +66,7 @@ class TFHubExtractor(Extractor):
         verify_dependencies(['tensorflow_hub'])
         if keras_args is None:
             keras_args = {}
+        self.keras_args = keras_args
         self.model = hub.KerasLayer(url_or_path, **keras_args)
         self.url_or_path = url_or_path
         self.features = features
@@ -134,6 +135,8 @@ class TFHubImageExtractor(TFHubExtractor):
                  keras_args=None):
         
         self.input_dtype = input_dtype
+        if keras_args is None:
+            keras_args = {}
         self.keras_args = keras_args
 
         logging.warning('Some models may require specific input shapes.'
@@ -191,8 +194,11 @@ class TFHubTextExtractor(TFHubExtractor):
                  output_key='default',
                  preprocessor_url_or_path=None, 
                  preprocessor_kwargs=None,
+                 keras_args=None,
                  **kwargs):
-        super().__init__(url_or_path, features, **kwargs)
+        super().__init__(url_or_path, features, 
+                         keras_args=keras_args, 
+                         **kwargs)
         self.output_key = output_key
         self.preprocessor_url_or_path=preprocessor_url_or_path
         self.preprocessor_kwargs = preprocessor_kwargs

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -138,7 +138,7 @@ class TFHubImageExtractor(TFHubExtractor):
         logging.warning('Some models may require specific input shapes.'
                         ' Incompatible shapes may raise errors'
                         ' at extraction. If needed, you can reshape'
-                        ' your input image using ImageResizingFilter,
+                        ' your input image using ImageResizingFilter, '
                         ' and rescale using ImageRescalingFilter')
         super().__init__(url_or_path, features, keras_args=keras_args)
 

--- a/pliers/extractors/models.py
+++ b/pliers/extractors/models.py
@@ -134,6 +134,7 @@ class TFHubImageExtractor(TFHubExtractor):
                  keras_args=None):
         
         self.input_dtype = input_dtype
+        self.keras_args = keras_args
 
         logging.warning('Some models may require specific input shapes.'
                         ' Incompatible shapes may raise errors'

--- a/pliers/filters/__init__.py
+++ b/pliers/filters/__init__.py
@@ -8,7 +8,8 @@ from .audio import (AudioTrimmingFilter,
 from .base import TemporalTrimmingFilter
 from .image import (ImageCroppingFilter,
                     ImageResizingFilter,
-                    PillowImageFilter)
+                    PillowImageFilter,
+                    ImageRescalingFilter)
 from .text import (WordStemmingFilter,
                    TokenizingFilter,
                    TokenRemovalFilter,
@@ -25,6 +26,7 @@ __all__ = [
     'ImageCroppingFilter',
     'ImageResizingFilter',
     'PillowImageFilter',
+    'ImageRescalingFilter',
     'WordStemmingFilter',
     'TokenizingFilter',
     'TokenRemovalFilter',

--- a/pliers/filters/image.py
+++ b/pliers/filters/image.py
@@ -157,21 +157,21 @@ class ImageRescalingFilter(ImageFilter):
 
     Args:
         scaling_factor (float): scaling factor by which pixel values 
-            are multiplied (defaults to 1/255.0 for RGB rescaling)
+            are divided (defaults to 255.0 for RGB rescaling)
         round_to (int): how many decimals to round new values to
     '''
 
     _log_attributes = ('scaling_factor', 'round_to',)
 
     def __init__(self, 
-                 scaling_factor=1/255.0, 
+                 scaling_factor=255.0, 
                  round_to=5):
         self.scaling_factor = scaling_factor
         self.round_to = round_to
         super().__init__()
 
     def _filter(self, stim):
-        new_img = stim.data * self.scaling_factor
+        new_img = stim.data / self.scaling_factor
         new_img = np.around(new_img, self.round_to)
         return ImageStim(stim.filename,
                          data=new_img)

--- a/pliers/filters/image.py
+++ b/pliers/filters/image.py
@@ -149,3 +149,30 @@ class PillowImageFilter(ImageFilter):
         new_img = np.array(pillow_img.filter(self.filter))
         return ImageStim(stim.filename,
                          data=new_img)
+
+
+class ImageRescalingFilter(ImageFilter):
+
+    ''' Rescales pixel values to (0,1)
+
+    Args:
+        scaling_factor (float): scaling factor by which pixel values 
+            are multiplied (defaults to 1/255.0 for RGB rescaling)
+        round_to (int): how many decimals to round new values to
+    '''
+
+    _log_attributes = ('scaling_factor', 'round_to',)
+
+    def __init__(self, 
+                 scaling_factor=1/255.0, 
+                 round_to=5):
+        self.scaling_factor = scaling_factor
+        self.round_to = round_to
+        super().__init__()
+
+    def _filter(self, stim):
+        new_img = stim.data * self.scaling_factor
+        new_img = np.around(new_img, self.round_to)
+        return ImageStim(stim.filename,
+                         data=new_img)
+

--- a/pliers/tests/extractors/test_model_extractors.py
+++ b/pliers/tests/extractors/test_model_extractors.py
@@ -67,6 +67,8 @@ def test_tensorflow_keras_application_extractor():
 
 def test_tfhub_image():
     stim = ImageStim(join(IMAGE_DIR, 'apple.jpg'))
+    rescale_filter = ImageRescalingFilter()
+    stim = rescale_filter.transform(stim)
     ext = TFHubImageExtractor(EFFNET_URL)
     df = ext.transform(stim).to_df()
     assert all(['feature_' + str(i) in df.columns \
@@ -81,10 +83,10 @@ def test_tfhub_image_reshape():
     rescale_filter = ImageRescalingFilter()
     resize_filter = ImageResizingFilter(size=(224,224), 
                                         maintain_aspect_ratio=False)
-    stim = rescale_filter.transform(stim)
-    stim2 = rescale_filter.transform(stim2)
     stim = resize_filter.transform(stim) 
     stim2 = resize_filter.transform(stim2)
+    stim = rescale_filter.transform(stim)
+    stim2 = rescale_filter.transform(stim2)
     ext = TFHubImageExtractor(MNET_URL,
                               features='feature_vector')
     df = merge_results(ext.transform([stim, stim2]),

--- a/pliers/tests/extractors/test_model_extractors.py
+++ b/pliers/tests/extractors/test_model_extractors.py
@@ -79,7 +79,7 @@ def test_tfhub_image_reshape():
     stim = ImageStim(join(IMAGE_DIR, 'apple.jpg'))
     stim2 = ImageStim(join(IMAGE_DIR, 'obama.jpg'))
     rescale_filter = ImageRescalingFilter()
-    resize_filter = ImageResizingFilter(size=(224,224,3), 
+    resize_filter = ImageResizingFilter(size=(224,224), 
                                         maintain_aspect_ratio=False)
     stim = rescale_filter.transform(stim)
     stim2 = rescale_filter.transform(stim2)

--- a/pliers/tests/extractors/test_model_extractors.py
+++ b/pliers/tests/extractors/test_model_extractors.py
@@ -15,7 +15,9 @@ from pliers.extractors import (TensorFlowKerasApplicationExtractor,
                                BertLMExtractor,
                                BertSentimentExtractor,
                                AudiosetLabelExtractor)
-from pliers.filters import AudioResamplingFilter
+from pliers.filters import (AudioResamplingFilter,
+                            ImageResizingFilter,
+                            ImageRescalingFilter)
 from pliers.stimuli import (ImageStim,
                             TextStim, ComplexTextStim,
                             AudioStim)
@@ -76,8 +78,14 @@ def test_tfhub_image():
 def test_tfhub_image_reshape():
     stim = ImageStim(join(IMAGE_DIR, 'apple.jpg'))
     stim2 = ImageStim(join(IMAGE_DIR, 'obama.jpg'))
+    rescale_filter = ImageRescalingFilter()
+    resize_filter = ImageResizingFilter(size=(224,224,3), 
+                                        maintain_aspect_ratio=False)
+    stim = rescale_filter.transform(stim)
+    stim2 = rescale_filter.transform(stim2)
+    stim = resize_filter.transform(stim) 
+    stim2 = resize_filter.transform(stim2)
     ext = TFHubImageExtractor(MNET_URL,
-                              reshape_input=(224,224,3),
                               features='feature_vector')
     df = merge_results(ext.transform([stim, stim2]),
                        extractor_names=False)

--- a/pliers/tests/extractors/test_text_extractors.py
+++ b/pliers/tests/extractors/test_text_extractors.py
@@ -1,7 +1,4 @@
 from os.path import join
-from pathlib import Path
-from os import environ
-import shutil
 import numpy as np
 import pytest
 import spacy
@@ -198,7 +195,7 @@ def test_spacy_token_extractor():
     result = ext.transform(stim).to_df()
     assert result['text'][0] == 'This'
     assert result['lemma_'][0].lower() == 'this'
-    assert result['pos_'][0] == 'DET'
+    assert result['pos_'][0] == 'PRON'
     assert result['tag_'][0] == 'DT'
     assert result['dep_'][0] == 'nsubj'
     assert result['shape_'][0] == 'Xxxx'

--- a/pliers/tests/filters/test_image_filters.py
+++ b/pliers/tests/filters/test_image_filters.py
@@ -1,9 +1,6 @@
 from os.path import join
-
 import numpy as np
-from pliers.filters.image import ImageRescalingFilter
 import pytest
-
 from ..utils import get_test_data_path
 from pliers.filters import (ImageCroppingFilter,
                             ImageResizingFilter,

--- a/pliers/tests/filters/test_image_filters.py
+++ b/pliers/tests/filters/test_image_filters.py
@@ -1,12 +1,14 @@
 from os.path import join
 
 import numpy as np
+from pliers.filters.image import ImageRescalingFilter
 import pytest
 
 from ..utils import get_test_data_path
 from pliers.filters import (ImageCroppingFilter,
                             ImageResizingFilter,
-                            PillowImageFilter)
+                            PillowImageFilter,
+                            ImageRescalingFilter)
 from pliers.stimuli import ImageStim
 
 IMAGE_DIR = join(get_test_data_path(), 'image')
@@ -79,3 +81,11 @@ def test_pillow_image_filter_filter():
     filt5 = PillowImageFilter(ImageFilter.MaxFilter, size=3)
     med_img = filt5.transform(stim)
     assert np.array_equal(med_img.data[0, 0], [136, 86, 49])
+
+
+def test_image_rescaling_filter():
+    stim = ImageStim(join(IMAGE_DIR, 'thai_people.jpg'))
+    filt = ImageRescalingFilter()
+    rescaled = filt.transform(stim)
+    assert (rescaled.data >= 0).all()
+    assert (rescaled.data <= 1).all()


### PR DESCRIPTION
@anibalsolon This is my suggestion for your PR.

Basically, applying transformations within an Extractor is not very "pliers"-y. It makes more sense to do your transformations before using the extractor. 

So I removed all of that, and instead the user can do it themselves.

Also, I changed the `kwargs` to `kergs_args` to be more explicit, and make it impossible to set `transform_inp` for the `TFHubImageExtractor`. You should not need it (or am I wrong and you do?)

The only thing left to do would be to implement `ImageReescalingFilter` to scale from RGB to (0, 1) which would be a useful filter to have in any case.

WDYT?

cc: @rbroc
